### PR TITLE
fix: #9 adapt initialiser parameter to OpenSSL::PKey implementation

### DIFF
--- a/lib/keystores/jks/pkcs8_key.rb
+++ b/lib/keystores/jks/pkcs8_key.rb
@@ -6,14 +6,18 @@ module OpenSSL
     class EC
       original_initialize = instance_method(:initialize)
 
-      define_method(:initialize) do |der_or_pem|
+      define_method(:initialize) do |*several_variants|
         init = original_initialize.bind(self)
         begin
-          init.(der_or_pem)
+          init.(*several_variants)
         rescue Exception
           # If we blow up trying to parse the key, we might be der encoded PKCS8, and if we are, convert ourselves
           # to PEM and try again.
-          init.(OpenSSL::PKey.der_to_pem(der_or_pem))
+          if several_variants.count == 1
+            init.(OpenSSL::PKey.der_to_pem(*several_variants))
+          else
+            raise
+          end
         end
       end
 
@@ -60,14 +64,18 @@ module OpenSSL
     class RSA
       original_initialize = instance_method(:initialize)
 
-      define_method(:initialize) do |der_or_pem|
+      define_method(:initialize) do |*several_variants|
         init = original_initialize.bind(self)
         begin
-          init.(der_or_pem)
+          init.(*several_variants)
         rescue Exception
           # If we blow up trying to parse the key, we might be der encoded PKCS8, and if we are, convert ourselves
           # to PEM and try again.
-          init.(OpenSSL::PKey.der_to_pem(der_or_pem))
+          if several_variants.count == 1
+            init.(OpenSSL::PKey.der_to_pem(*several_variants))
+          else
+            raise
+          end
         end
       end
 
@@ -105,14 +113,18 @@ module OpenSSL
     class DSA
       original_initialize = instance_method(:initialize)
 
-      define_method(:initialize) do |der_or_pem|
+      define_method(:initialize) do |*several_variants|
         init = original_initialize.bind(self)
         begin
-          init.(der_or_pem)
+          init.(*several_variants)
         rescue Exception
           # If we blow up trying to parse the key, we might be der encoded PKCS8, and if we are, convert ourselves
           # to PEM and try again.
-          init.(OpenSSL::PKey.der_to_pem(der_or_pem))
+          if several_variants.count == 1
+            init.(OpenSSL::PKey.der_to_pem(*several_variants))
+          else
+            raise
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #9 

Instead of one parameters it allows a series of parameters (including none). The parameters are now conform with the actual implementation, see e.g.: https://ruby-doc.org/stdlib-2.6.1/libdoc/openssl/rdoc/OpenSSL/PKey/RSA.html

This mostly caused issues when none was given - part of the jwt gem initialisation process at it seems - since at least one parameter was expected. 

However, it also adds an additional check to avoid issues when a different number of parameters are given: otherwise `der_to_pem` could raise an error - hiding the true error from the PKey initialisers

Also, it should be backwards compatible for older jwt gem versions.